### PR TITLE
Support HTTPS Phabricator URLs

### DIFF
--- a/agent/src/main/java/com/couchmate/teamcity/phabricator/tasks/HarbormasterBuildStatus.java
+++ b/agent/src/main/java/com/couchmate/teamcity/phabricator/tasks/HarbormasterBuildStatus.java
@@ -39,8 +39,8 @@ public class HarbormasterBuildStatus extends Task {
     @Override
     protected void setup() {
         URI uri;
-        String scheme = null;
         String url = this.appConfig.getPhabricatorUrl();
+        String scheme = null;
         String host = null;
         try {
             uri = new URI(url);

--- a/agent/src/main/java/com/couchmate/teamcity/phabricator/tasks/HarbormasterBuildStatus.java
+++ b/agent/src/main/java/com/couchmate/teamcity/phabricator/tasks/HarbormasterBuildStatus.java
@@ -38,24 +38,10 @@ public class HarbormasterBuildStatus extends Task {
 
     @Override
     protected void setup() {
-        URI uri;
-        String url = this.appConfig.getPhabricatorUrl();
-        String scheme = null;
-        String host = null;
-        try {
-            uri = new URI(url);
-            scheme = uri.getScheme();
-            host = uri.getHost();
-        } catch (URISyntaxException e) {
-            // Don't die here, just use default values of "http" and the url as the path
-            e.printStackTrace();
-        }
-
         try {
             this.httpPost = (HttpPost) new HttpRequestBuilder()
                     .post()
-                    .setScheme(scheme == null ? "http" : scheme)
-                    .setHost(host == null ? url : host)
+                    .setUrl(this.appConfig.getPhabricatorUrl())
                     .setPath("/api/harbormaster.sendmessage")
                     .addFormParam(new StringKeyValue("api.token", this.appConfig.getConduitToken()))
                     .addFormParam(new StringKeyValue("type", parseTeamCityBuildStatus(this.buildFinishedStatus)))

--- a/agent/src/main/java/com/couchmate/teamcity/phabricator/tasks/HarbormasterBuildStatus.java
+++ b/agent/src/main/java/com/couchmate/teamcity/phabricator/tasks/HarbormasterBuildStatus.java
@@ -10,6 +10,9 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 /**
  * Created by mjo20 on 10/31/2015.
  */
@@ -21,12 +24,13 @@ public class HarbormasterBuildStatus extends Task {
     private Gson gson;
     private HttpPost httpPost = null;
 
-    private HarbormasterBuildStatus(){}
+    private HarbormasterBuildStatus() {
+    }
 
     public HarbormasterBuildStatus(
             final AppConfig appConfig,
             final BuildFinishedStatus buildFinishedStatus
-    ){
+    ) {
         this.appConfig = appConfig;
         this.buildFinishedStatus = buildFinishedStatus;
         this.gson = new Gson();
@@ -34,24 +38,41 @@ public class HarbormasterBuildStatus extends Task {
 
     @Override
     protected void setup() {
+        URI uri;
+        String scheme = "http";
+        String url = this.appConfig.getPhabricatorUrl();
+        String host = null;
+        try {
+            uri = new URI(url);
+            scheme = uri.getScheme();
+            host = uri.getHost();
+        } catch (URISyntaxException e) {
+            // Don't die here, just use default values of "http" and the url as the path
+            e.printStackTrace();
+        }
+
         try {
             this.httpPost = (HttpPost) new HttpRequestBuilder()
                     .post()
-                    .setScheme("http")
-                    .setHost(this.appConfig.getPhabricatorUrl())
+                    .setScheme(scheme)
+                    .setHost(host == null ? url : host)
                     .setPath("/api/harbormaster.sendmessage")
                     .addFormParam(new StringKeyValue("api.token", this.appConfig.getConduitToken()))
                     .addFormParam(new StringKeyValue("type", parseTeamCityBuildStatus(this.buildFinishedStatus)))
                     .addFormParam(new StringKeyValue("buildTargetPHID", this.appConfig.getHarbormasterTargetPHID()))
                     .build();
-        } catch (Exception e) { e.printStackTrace(); }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     @Override
     protected void execute() {
-        try(CloseableHttpClient httpClient = HttpClients.createDefault()){
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
             httpClient.execute(this.httpPost);
-        } catch (Exception e) { e.printStackTrace(); }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     @Override
@@ -59,8 +80,8 @@ public class HarbormasterBuildStatus extends Task {
 
     }
 
-    private String parseTeamCityBuildStatus(BuildFinishedStatus buildFinishedStatus){
-        switch (buildFinishedStatus){
+    private String parseTeamCityBuildStatus(BuildFinishedStatus buildFinishedStatus) {
+        switch (buildFinishedStatus) {
             case FINISHED_SUCCESS:
                 return "pass";
             case FINISHED_FAILED:

--- a/agent/src/main/java/com/couchmate/teamcity/phabricator/tasks/HarbormasterBuildStatus.java
+++ b/agent/src/main/java/com/couchmate/teamcity/phabricator/tasks/HarbormasterBuildStatus.java
@@ -39,7 +39,7 @@ public class HarbormasterBuildStatus extends Task {
     @Override
     protected void setup() {
         URI uri;
-        String scheme = "http";
+        String scheme = null;
         String url = this.appConfig.getPhabricatorUrl();
         String host = null;
         try {
@@ -54,7 +54,7 @@ public class HarbormasterBuildStatus extends Task {
         try {
             this.httpPost = (HttpPost) new HttpRequestBuilder()
                     .post()
-                    .setScheme(scheme)
+                    .setScheme(scheme == null ? "http" : scheme)
                     .setHost(host == null ? url : host)
                     .setPath("/api/harbormaster.sendmessage")
                     .addFormParam(new StringKeyValue("api.token", this.appConfig.getConduitToken()))

--- a/common/src/main/java/com/couchmate/teamcity/phabricator/HttpRequestBuilder.java
+++ b/common/src/main/java/com/couchmate/teamcity/phabricator/HttpRequestBuilder.java
@@ -1,12 +1,10 @@
 package com.couchmate.teamcity.phabricator;
 
-import com.couchmate.teamcity.phabricator.TCPhabException;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.message.BasicHeader;
 import org.apache.http.message.BasicNameValuePair;
 
 import java.io.UnsupportedEncodingException;
@@ -17,6 +15,10 @@ import java.util.List;
 
 public final class HttpRequestBuilder {
 
+    public static final int HTTPS_PORT = 443;
+    public static final int HTTP_PORT = 80;
+    public static final String HTTP_SCHEME = "http";
+    public static final String HTTPS_SCHEME = "https";
     private HttpRequestBase httpRequest = null;
     private URI uri = null;
     private String host = null;
@@ -27,7 +29,7 @@ public final class HttpRequestBuilder {
     private StringEntity body = null;
     private List<BasicNameValuePair> formParams = new ArrayList<>();
 
-    public HttpRequestBuilder get(){
+    public HttpRequestBuilder get() {
         this.httpRequest = new HttpGet();
         return this;
     }
@@ -37,62 +39,88 @@ public final class HttpRequestBuilder {
         return this;
     }
 
-    public HttpRequestBuilder setScheme(String scheme){
-        if(CommonUtils.isNullOrEmpty(scheme)) throw new IllegalArgumentException("Must provide a valid scheme");
-        else if (!scheme.equals("http") && !scheme.equals("https")) throw new IllegalArgumentException(String.format("Scheme %s is not supported", scheme));
+    /**
+     * Sets the scheme, host and port based on the url.
+     *
+     * @param url Url of the form "http://example.com", "https://example.com" or "example.com" where "http is implied
+     */
+    public HttpRequestBuilder setUrl(String url) {
+        URI uri;
+        String scheme = null;
+        String host = null;
+        try {
+            uri = new URI(url);
+            scheme = uri.getScheme();
+            host = uri.getHost();
+        } catch (URISyntaxException e) {
+            // Don't die here, just use default values of "http" and the url as the path
+        }
+        scheme = scheme == null ? HTTP_SCHEME : scheme;
+        host = host == null ? url : host;
+
+        setScheme(scheme);
+        setHost(host);
+        setPort(scheme.equals(HTTPS_SCHEME) ? HTTPS_PORT : HTTP_PORT);
+        return this;
+    }
+
+    public HttpRequestBuilder setScheme(String scheme) {
+        if (CommonUtils.isNullOrEmpty(scheme)) throw new IllegalArgumentException("Must provide a valid scheme");
+        else if (!scheme.equals("http") && !scheme.equals("https"))
+            throw new IllegalArgumentException(String.format("Scheme %s is not supported", scheme));
         else this.scheme = scheme;
         return this;
     }
 
-    public HttpRequestBuilder setHost(String host){
-        if(CommonUtils.isNullOrEmpty(host)) throw new IllegalArgumentException("Must provide a valid host");
+    public HttpRequestBuilder setHost(String host) {
+        if (CommonUtils.isNullOrEmpty(host)) throw new IllegalArgumentException("Must provide a valid host");
         else this.host = host;
         return this;
     }
 
-    public HttpRequestBuilder setPort(int port){
+    public HttpRequestBuilder setPort(int port) {
         this.port = port;
         return this;
     }
 
-    public HttpRequestBuilder setPath(String path){
-        if(CommonUtils.isNullOrEmpty(path)) throw new IllegalArgumentException("Must provide a valid path");
+    public HttpRequestBuilder setPath(String path) {
+        if (CommonUtils.isNullOrEmpty(path)) throw new IllegalArgumentException("Must provide a valid path");
         else this.path = path;
         return this;
     }
 
-    public HttpRequestBuilder setParam(String key, String value){
-        if(CommonUtils.isNullOrEmpty(key)) throw new IllegalArgumentException("Must provide a valid param");
+    public HttpRequestBuilder setParam(String key, String value) {
+        if (CommonUtils.isNullOrEmpty(key)) throw new IllegalArgumentException("Must provide a valid param");
         else this.params.add(new StringKeyValue(key, value));
         return this;
     }
 
-    public HttpRequestBuilder setParams(List<StringKeyValue> params){
-        for(StringKeyValue param : params){
+    public HttpRequestBuilder setParams(List<StringKeyValue> params) {
+        for (StringKeyValue param : params) {
             this.params.add(param);
         }
         return this;
     }
 
     public HttpRequestBuilder setBody(String body) throws UnsupportedEncodingException {
-        if(CommonUtils.isNullOrEmpty(body)) throw new IllegalArgumentException("Must provide a valid body");
-        else{
+        if (CommonUtils.isNullOrEmpty(body)) throw new IllegalArgumentException("Must provide a valid body");
+        else {
             this.body = new StringEntity(body);
         }
         return this;
     }
 
-    public HttpRequestBuilder addFormParam(StringKeyValue keyValue){
+    public HttpRequestBuilder addFormParam(StringKeyValue keyValue) {
         this.formParams.add(new BasicNameValuePair(keyValue.getKey(), keyValue.getValue()));
         return this;
     }
 
     public HttpRequestBase build() throws TCPhabException, URISyntaxException {
-        if(httpRequest == null) throw new TCPhabException("Must provide a method");
-        if(CommonUtils.isNullOrEmpty(scheme)) throw new TCPhabException("Must provide a scheme");
-        if(CommonUtils.isNullOrEmpty(host)) throw new TCPhabException("Must provide a host");
-        if(port == null) this.port = 80;
-        if(CommonUtils.isNullOrEmpty(path)) throw new TCPhabException("Must provide a path");
+        if (httpRequest == null) throw new TCPhabException("Must provide a method");
+        if (CommonUtils.isNullOrEmpty(scheme)) throw new TCPhabException("Must provide a scheme");
+        if (CommonUtils.isNullOrEmpty(host)) throw new TCPhabException("Must provide a host");
+        if (port == null) this.port = HTTP_PORT;
+        if (CommonUtils.isNullOrEmpty(path)) throw new TCPhabException("Must provide a path");
 
         this.uri = new URI(
                 this.scheme,
@@ -104,27 +132,29 @@ public final class HttpRequestBuilder {
                 null
         );
 
-        if(httpRequest instanceof HttpGet) httpRequest.setURI(this.uri);
-        if(httpRequest instanceof HttpPost) {
+        if (httpRequest instanceof HttpGet) httpRequest.setURI(this.uri);
+        if (httpRequest instanceof HttpPost) {
             httpRequest.setURI(this.uri);
-            if(!this.formParams.isEmpty()){
+            if (!this.formParams.isEmpty()) {
                 try {
                     ((HttpPost) httpRequest).setEntity(new UrlEncodedFormEntity(this.formParams));
-                } catch (Exception e) { e.printStackTrace(); }
-            }
-            else if(this.body != null) ((HttpPost) httpRequest).setEntity(this.body);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            } else if (this.body != null) ((HttpPost) httpRequest).setEntity(this.body);
         }
 
         return httpRequest;
     }
 
-    private String paramBuilder(){
+    private String paramBuilder() {
         StringBuilder stringBuilder = new StringBuilder();
-        if(this.params.isEmpty()) return null;
+        if (this.params.isEmpty()) return null;
         else {
-            for(int i = 0; i < this.params.size() ; i++){
+            for (int i = 0; i < this.params.size(); i++) {
                 KeyValue param = this.params.get(i);
-                if(i == this.params.size() - 1) stringBuilder.append(String.format("%s=%s", param.getKey(), param.getValue()));
+                if (i == this.params.size() - 1)
+                    stringBuilder.append(String.format("%s=%s", param.getKey(), param.getValue()));
                 else stringBuilder.append(String.format("%s=%s&", param.getKey(), param.getValue()));
             }
             return stringBuilder.toString();

--- a/common/src/main/java/com/couchmate/teamcity/phabricator/HttpRequestBuilder.java
+++ b/common/src/main/java/com/couchmate/teamcity/phabricator/HttpRequestBuilder.java
@@ -42,7 +42,7 @@ public final class HttpRequestBuilder {
     /**
      * Sets the scheme, host and port based on the url.
      *
-     * @param url Url of the form "http://example.com", "https://example.com" or "example.com" where "http is implied
+     * @param url Url of the form "http://example.com", "https://example.com" or "example.com" where "http" is implied
      */
     public HttpRequestBuilder setUrl(String url) {
         URI uri;
@@ -54,6 +54,7 @@ public final class HttpRequestBuilder {
             host = uri.getHost();
         } catch (URISyntaxException e) {
             // Don't die here, just use default values of "http" and the url as the path
+            e.printStackTrace();
         }
         scheme = scheme == null ? HTTP_SCHEME : scheme;
         host = host == null ? url : host;

--- a/server/src/main/java/com/couchmate/teamcity/phabricator/BuildTracker.java
+++ b/server/src/main/java/com/couchmate/teamcity/phabricator/BuildTracker.java
@@ -70,8 +70,8 @@ public class BuildTracker implements Runnable {
     }
 
     private void sendTestReport(String testName, STestRun test) {
-        URI uri = null;
-        String scheme = "http";
+        URI uri;
+        String scheme = null;
         String url = this.appConfig.getPhabricatorUrl();
         String host = null;
         try {
@@ -85,7 +85,7 @@ public class BuildTracker implements Runnable {
 
         HttpRequestBuilder httpPost = new HttpRequestBuilder()
                 .post()
-                .setScheme(scheme)
+                .setScheme(scheme == null ? "http" : scheme)
                 .setHost(host == null ? url : host)
                 .setPath("/api/harbormaster.sendmessage")
                         //.setBody(payload.toString())
@@ -93,7 +93,7 @@ public class BuildTracker implements Runnable {
                 .addFormParam(new StringKeyValue("buildTargetPHID", this.appConfig.getHarbormasterTargetPHID()))
                 .addFormParam(new StringKeyValue("type", "work"))
                 .addFormParam(new StringKeyValue("unit[0][name]", test.getTest().getName().getTestMethodName()))
-                //.addFormParam(new StringKeyValue("unit[0][duration]", String.valueOf(test.getDuration())))
+                        //.addFormParam(new StringKeyValue("unit[0][duration]", String.valueOf(test.getDuration())))
                 .addFormParam(new StringKeyValue("unit[0][namespace]", test.getTest().getName().getClassName()));
 
         if (test.getStatus().isSuccessful()) {

--- a/server/src/main/java/com/couchmate/teamcity/phabricator/BuildTracker.java
+++ b/server/src/main/java/com/couchmate/teamcity/phabricator/BuildTracker.java
@@ -70,23 +70,9 @@ public class BuildTracker implements Runnable {
     }
 
     private void sendTestReport(String testName, STestRun test) {
-        URI uri;
-        String url = this.appConfig.getPhabricatorUrl();
-        String scheme = null;
-        String host = null;
-        try {
-            uri = new URI(url);
-            scheme = uri.getScheme();
-            host = uri.getHost();
-        } catch (URISyntaxException e) {
-            // Don't die here, just use default values of "http" and the url as the path
-            e.printStackTrace();
-        }
-
         HttpRequestBuilder httpPost = new HttpRequestBuilder()
                 .post()
-                .setScheme(scheme == null ? "http" : scheme)
-                .setHost(host == null ? url : host)
+                .setUrl(this.appConfig.getPhabricatorUrl())
                 .setPath("/api/harbormaster.sendmessage")
                         //.setBody(payload.toString())
                 .addFormParam(new StringKeyValue("api.token", this.appConfig.getConduitToken()))

--- a/server/src/main/java/com/couchmate/teamcity/phabricator/BuildTracker.java
+++ b/server/src/main/java/com/couchmate/teamcity/phabricator/BuildTracker.java
@@ -71,8 +71,8 @@ public class BuildTracker implements Runnable {
 
     private void sendTestReport(String testName, STestRun test) {
         URI uri;
-        String scheme = null;
         String url = this.appConfig.getPhabricatorUrl();
+        String scheme = null;
         String host = null;
         try {
             uri = new URI(url);

--- a/server/src/main/java/com/couchmate/teamcity/phabricator/BuildTracker.java
+++ b/server/src/main/java/com/couchmate/teamcity/phabricator/BuildTracker.java
@@ -93,7 +93,7 @@ public class BuildTracker implements Runnable {
                 .addFormParam(new StringKeyValue("buildTargetPHID", this.appConfig.getHarbormasterTargetPHID()))
                 .addFormParam(new StringKeyValue("type", "work"))
                 .addFormParam(new StringKeyValue("unit[0][name]", test.getTest().getName().getTestMethodName()))
-                        //.addFormParam(new StringKeyValue("unit[0][duration]", String.valueOf(test.getDuration())))
+                //.addFormParam(new StringKeyValue("unit[0][duration]", String.valueOf(test.getDuration())))
                 .addFormParam(new StringKeyValue("unit[0][namespace]", test.getTest().getName().getClassName()));
 
         if (test.getStatus().isSuccessful()) {


### PR DESCRIPTION
This adds the `setUrl` method in HttpRequestBuilder which takes a Url and calls into `setScheme`, `setHost` and `setPort` as appropriate. This adds support for `https` phabricator urls instead of assuming `http` like before.
